### PR TITLE
Make sure old ABI is used on GCC 5.2+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,13 @@ else
 	LINKFLAGS+= -pie -m64 -Wl,-rpath,$(LD_LIBRARY_PATH)
 endif
 
+CHECKGCCABI := $(shell expr `gcc -dumpversion | cut -f1 -d.` \>= 4)
+ifeq ("CHECKGCCABI","1")
+	CXXFLAGS+= -D_GLIBCXX_USE_CXX11_ABI=0
+	CXXFLAGSUTIL+= -D_GLIBCXX_USE_CXX11_ABI=0
+	LINKFLAGS+= -D_GLIBCXX_USE_CXX11_ABI=0
+endif
+
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,13 @@ CXXFLAGS_LIB = $(CXXFLAGS_BASE) -I$(INCDIR) -I$(INCPDFDIR) -I$(INCDALITZDIR) -I$
 
 LIBLINKFLAGS = -pie -m64
 
+CHECKGCCABI := $(shell expr `gcc -dumpversion | cut -f1 -d.` \>= 5)
+ifeq ("$(CHECKGCCABI)","1")
+	CXXFLAGS+= -D_GLIBCXX_USE_CXX11_ABI=0
+	CXXFLAGSUTIL+= -D_GLIBCXX_USE_CXX11_ABI=0
+	LINKFLAGS+= -D_GLIBCXX_USE_CXX11_ABI=0
+endif
+
 # OS X
 DARWIN=Darwin
 ifeq ($(UNAME),$(Darwin))
@@ -121,13 +128,6 @@ else
 	CXXFLAGS+= -fPIE
 	CXXFLAGSUTIL+= -fPIE
 	LINKFLAGS+= -pie -m64 -Wl,-rpath,$(LD_LIBRARY_PATH)
-endif
-
-CHECKGCCABI := $(shell expr `gcc -dumpversion | cut -f1 -d.` \>= 5)
-ifeq ("CHECKGCCABI","1")
-	CXXFLAGS+= -D_GLIBCXX_USE_CXX11_ABI=0
-	CXXFLAGSUTIL+= -D_GLIBCXX_USE_CXX11_ABI=0
-	LINKFLAGS+= -D_GLIBCXX_USE_CXX11_ABI=0
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ else
 	LINKFLAGS+= -pie -m64 -Wl,-rpath,$(LD_LIBRARY_PATH)
 endif
 
-CHECKGCCABI := $(shell expr `gcc -dumpversion | cut -f1 -d.` \>= 4)
+CHECKGCCABI := $(shell expr `gcc -dumpversion | cut -f1 -d.` \>= 5)
 ifeq ("CHECKGCCABI","1")
 	CXXFLAGS+= -D_GLIBCXX_USE_CXX11_ABI=0
 	CXXFLAGSUTIL+= -D_GLIBCXX_USE_CXX11_ABI=0


### PR DESCRIPTION
ROOT  does not always play well with the new binary ABI that comes with GCC 5.2+. Make sure to use the old ABI for compatibility